### PR TITLE
Remove redundant if condition

### DIFF
--- a/lib/src/fov.dart
+++ b/lib/src/fov.dart
@@ -18,7 +18,7 @@ class Fov {
     }
 
     // The starting position is always visible.
-    if (_demo.tiles[pos].isVisible = true);
+    _demo.tiles[pos].isVisible = true;
   }
 
   List<Shadow> refreshOctant(Vec start, int octant, [int maxRows = 999]) {


### PR DESCRIPTION
The "if" condition around statement `_demo.tiles[pos].isVisible = true` has no body and can be safely removed (I think).

From reddit post: https://www.reddit.com/r/dartlang/comments/9tnrgl/could_someone_please_tell_me_what_this_if/